### PR TITLE
Changed Valberedningen a sane name

### DIFF
--- a/namnder/valberedningen/meta.toml
+++ b/namnder/valberedningen/meta.toml
@@ -1,2 +1,2 @@
 Image = "https://stacken.är.den.verkligen.uppe/a.png"
-Title = "Datasektionens Valberedning"
+Title = "Valberedningen"


### PR DESCRIPTION
The title was Datasektionens Valberedning. Changed it to Valberedningen.