### PR TITLE
Ta bort redundant information från /sektionen och /namnder.

### DIFF
--- a/namnder/body.md
+++ b/namnder/body.md
@@ -1,51 +1,6 @@
 # Nämnder på Datasektionen
 
-###[DKM – Datas Klubbmästeri](/namnder/dkm)
-Vad vore en sektion utan fester? Datasektionens Klubbmästeri har fixat fester lika länge som sektionen funnits till.
-
-###[dbuggen](http://dbu.gg)
-dbuggen är Datas sektionstidning. Den utkommer när en eventuell redaktion har tid och fantasi, vilket händer inte alltför sällan. Numera kan du, förutom att läsa den mycket uppskattade papperstidningen, även läsa dbuggen online.
-
-###[METAdorerna](/namnder/metadorerna)
-Vår gemensamma sektionslokal heter META och ligger på Osquars Backe 21. META vårdas av sektionslokalsgruppen METAdorerna.
-
-###[IOR – Informationsorganet för Datasektionen](/namnder/informationsorganet)
-Vi ägnar oss åt att samla in och sprida ut information på Datasektionen.
-
-###[Tag Monkeys – Datas ritapor](/namnder/tag-monkeys)
-Grafisk design <3
-
-###[Jämlikhetsnämnden](/namnder/jamlikhetsnamnden)
-Nämnden som gör allt för att alla ska känna sig trygga och välkomna på Konglig Datasektionen.
-
-###[KÖN – Konglig Östrogennämnden](/namnder/konglig-ostrogennamnden)
-Nämnden som hjälper tjejer på data att nätverka med varandra.
-
-###[Mottagningen](/namnder/mottagningen)
-Har hand om mottagningen av de nya som börjar på Datasektionen. Här hittar du information om vem som är vem, samt när och var alla fester och annat skoj händer.
-
-###[Näringslivsgruppen](/namnder/naringslivsgruppen)
-Näringslivsgruppen ansvarar för Datasektionens näringslivskontakter vilket innefattar bl.a. arbetsmarknadsdagar, studiebesök på intressanta företag samt olika former av sponsring.
-
-###[Prylmångleriet](/namnder/prylmangleriet)
-Prylis säljer saker såsom sångböcker och märken till köpsugna teknologer.
-
-###[Qulturnämnden](/namnder/qulturnamnden)
-Qulturnämnden ombesörjer sektionens kulturella verksamhet i form av exempelvis filmvisningar och godisförsäljning.
-
-###[Idrottsnämnden](/namnder/idrottsnamnden)
-Idrottsnämndens aktiviteter beror helt på vad dess medlemmar vill göra.
-Vi satsar bl a på att delta i alla grenar i THS-Mästerskapen samt att
-hålla kontinuerliga aktiviteter vid sidan av studierna.
-
-###[Studienämnden](/namnder/studienamnden)
-Ägnar sig åt att granska undervisningen. Studienämndens huvudsakliga arbete består av att utvärdera kurserna och samtala med kursansvarig, så att förbättringar kan göras.
-
-###[DEMON – Datasektionens Musiknämnd](/namnder/datasektionens-musiknamnd)
-DEMON är Datas musikentusiaster som spelar musik tillsammans, DJ:ar musik och snackar om musik. Musik? Musik!
-
-###DESC – Datas E-Sports Community
-DESC anordnar spelkvällar för E-sportsentusiaster och tar tillvara på medlemmarnas intressen inom området.
+I menyn till vänster kan du läsa om alla Datasektionens nämnder.
 
 ## Projekt på Datasektionen
 
@@ -58,25 +13,6 @@ DESC anordnar spelkvällar för E-sportsentusiaster och tar tillvara på medlemm
 Vårbalen
 
 Sångboksgruppen
-
-[Bröllopet](https://www.facebook.com/brollopet2017)
-
-## Hur startar man projekt
-För att starta ett projetk så måste det ligga i sektionens intresse då det är sektionens pengar som kommer att användas.
-Därför för att starta ett nytt projekt måste en motion med följande saker lämnas in till nästkommande SM.
-För att starta ett Nytt projekt så krävs följande enligt stadgarna:
-
-- **Projektnamn**
-- **Syfte**
-- **Budget**
-- **Verksamhetsplan**
-- **Ungefärlig tidsplan**
-
-Vill man sen få rollen som projektledare för just sitt projekt krävs sen att man även har med en att-sats i motionen som säger att projektledaren ska väljas direkt av SM genom fri nominering. Om inte det finns med så väljs då denna genom samma procedur som för val av övriga funktionärer. 
-
-## Återupplivande av projekt. 
-Projekt som D-rektoratet anser vara återkommande kan då istället genom beslut på DM med en kort motivering innehållande referens till minst ett väldigt likartat tidigare projekt samt en uppskattning av de uppgifter, bortsett från budget, som krävs för att starta ett nytt projekt. Val av projektledare sker genom samma procedur som för val av övriga funktionärer vid nästkommande SM. Projektledare åläggs att inkomma med motion innehållandes budget samt verksamhetsplan för projektet till första möjliga SM efter valet, såvida SM inte redan beslutat om dessa för denna projektomgång.
-
 
 ## Tidigare nämnder och föreningar på Datasektionen
 

--- a/sektionen/body.md
+++ b/sektionen/body.md
@@ -1,195 +1,77 @@
 # Konglig Datasektionen
 
-Datasektionen är en ideell
-[studentsektion](https://sv.wikipedia.org/wiki/Studentsektion) under
-[Tekniska Högskolans Studentkår](http://ths.kth.se) som finns till för
-att alla som läser Datateknik på KTH ska få en så bra studietid som
-möjligt. Dels genom att bevaka kurserna som vi läser, dels genom att
-ordna aktiviteter utanför studierna. På sektionen finns det flera
-nämnder, som var och en håller på med det som intresserar dem. Du kan
-läsa mer om olika saker de gör här nedan.
+Datasektionen är en ideell [studentsektion](https://sv.wikipedia.org/wiki/Studentsektion) under [Tekniska Högskolans Studentkår](http://ths.kth.se) som finns till för att alla som läser Datateknik på KTH ska få en så bra studietid som möjligt, dels genom att bevaka kurserna som vi läser och dels genom att ordna aktiviteter utanför studierna. På sektionen finns det flera nämnder som har olika verksamhet. Du kan läsa mer om olika saker de gör här nedan.
 
-Festverksamhet, DKM
--------------------
+## Festverksamhet
 
-Fester är något en teknolog sällan klarar sig utan i mer än ett par
-dagar. För att tillfredsställa behoven finns Datas Klubbmästeri.
-[DKM](/namnder/dkm), som det så enkelt kallas i lekmannatermer, består av ett
-gäng som definitivt har examen att anordna helt bonkers fester. Nu tycker du
-säkert att det här låter extremt bra - det är det.
+Fester är något en teknolog sällan klarar sig utan i mer än ett par dagar. För att tillfredsställa behoven finns Datas Klubbmästeri. [DKM](/namnder/dkm), som det så enkelt kallas i lekmannatermer, består av ett gäng som definitivt har examen att anordna helt bonkers fester. Du tycker säkert att det här låter extremt bra - det är det.
 
-Underhållning och aktiviteter
------------------------------
+## Studiebevakning
 
-På Konglig Datasektionen finns det många sätt att roa sig. Förutom
-studier i intressanta ämnen och episka fester anordnas det även
-qulturella tillställningar, så som film- och spelkvällar. Vi samarbetar
-även med andra föreningar för att tillsammans sprida qultur över campus.
-Söker du sällskap till ett qulturellt arrangemang, eller har du planer
-på att anordna ett eget? Vänd dig till oss så hjälper vi dig.
+[Studienämnden](/namnder/studienamnden) ansvarar för att granska och förbättra utbildningen. Om du upplever något problem med hur en kurs, någon lärare eller liknande är det till Studienämnden du ska vända dig! Studienämnden är öppen för alla dataloger - vem som helst får komma på våra möten och alla som vill är välkomna att gå med i nämnden.
 
-Studiebevakning
----------------
+## Näringslivskontakt
 
-Studienämnden ansvarar för att alla dataloger får en så bra utbildning
-som möjligt. Vi träffas minst en gång per läsperiod och diskuterar hur
-det går i olika kurser och masterprogram. Om du upplever något problem
-med studievägledningen eller hur en kurs fungerar är det till oss du ska
-vända dig! Studienämnden är öppen för alla dataloger - vem som helst får
-komma på våra möten och alla som vill är välkomna att gå med i nämnden.
-
-Näringslivskontakt
-------------------
-
-Näringslivsgruppen står för sektionens kontakt med näringslivet och vi
-ordnar tillsammans med företag och andra branschorganisationer olika
-event som den årliga arbetsmarknadsdagen D-Dagen men även företagspubar,
-föreläsningar och lite andra mer speciella arrangemang. Vi hjälper även
-till med att förmedla jobb genom annonser i olika medium och ibland har
+[Näringslivsgruppen](/namnder/naringslivsgruppen) står för sektionens kontakt med näringslivet. Gruppen anordnar tillsammans med företag och andra branschorganisationer olika event, som t.ex. den årliga arbetsmarknadsdagen D-Dagen, företagspubar, föreläsningar och andra mer speciella arrangemang. De hjälper även till med att förmedla jobb genom annonser i olika medium och ibland har
 vi lite olika specialerbjudanden.
 
-Sektionslokal
--------------
+## Underhållning och aktiviteter
 
-Datasektionens och Sektionen för Medietekniks gemensamma sektionslokal
-heter META och är det utrymme på KTH där våra sektionsmedlemmar kan
-umgås, äta och studera mellan föreläsningarna. META ligger på Osquars
-Backe 21 och tas hand om sektionslokalsgruppen METAdorerna.
+På Konglig Datasektionen finns det många sätt att roa sig. Förutom studier i intressanta ämnen och episka fester anordnas det även qulturella tillställningar och många aktiviteter. 
+[Qulturnämnden](/namnder/qulturnamnden) ombesörjer sektionens kulturella verksamhet i form av exempelvis filmvisningar, spelkvällar och godisförsäljning. 
+[Idrottsnämnden](/namnder/idrottsnamnden) gör vad dess medlemmar vill, bl.a. delta i THS-mästerskapen samt att hålla veckovisa aktiviteter. 
+DESC - Datas E-Sports Community - anordnar spelkvällar för E-sportsentusiaster
 
-Informationsspridning
----------------------
+## Jämlikhet
 
-Informationsorganet har som främsta syfte att sprida information – till,
-från och mellan Datasektionens medlemmar. Det är vi som underhåller och
-utvecklar vår hemsida, ser till att nyhetsbrev kommer ut löpande och
-håller koll på sektionens grafiska profil.
+[Jämlikhetsnämnden](/namnder/jamlikhetsnamnden) gör allt för att alla ska känna sig trygga och lika välkomna på Konglig Datasektionen. Hit vänder du dig om du har frågor om trakasserier, diskriminering, eller om du utsatts för något otrevligt på sektionen.
 
-Mottagning av nya studenter
----------------------------
+## Tjejer på data
 
-Mottagningen ser till att de nyantagna till Datasektionen känner sig
-välkommna och har roligt. Du hittar schema och mer information om
-mottagningen på [mottagningens sida](/namnder/mottagningen).
+Trots Datasektionens så få men ack så underbara tjejer finns ett ljus i tunneln: [Konglig Östrogennämnden](/namnder/konglig-ostrogennamnden) är nämnden som hjälper tjejer på data att nätverka med varandra. De anordnar företagsevent och tjejgasquen.
 
-Styrelse
---------
+## Sektionslokal
 
-Styrelsen, eller ”D-rektoratet”, har det övergripande ansvaret för allt
-som händer på sektionen. Styrelsens ansvarsområden är uppdelade mellan
-dess medlemmar. Är man medlem i sektionen kan man också bli invald i
-styrelsen på ett sektionsmöte, så kallat "SM". Styrelsens huvuduppgift
-är genomföra beslut som tas på SM.
+Datasektionens och Sektionen för Medietekniks gemensamma sektionslokal heter META och är det utrymme på KTH där våra sektionsmedlemmar kan umgås, äta och studera mellan föreläsningarna. META ligger på Osquars Backe 21 och tas hand om sektionslokalsgruppen [METAdorerna](/namnder/metadorerna).
 
-Kårfullmäktigeledamöter
------------------------
+## Informationsspridning
 
-Datasektionens kårfullmäktigeledamöter representerar sektionen i
-Kårfullmäktige, KF, som är Tekniska Högskolans Studentkår, THS, högsta
-beslutande organ. Kårfullmäktige bestämmer bland annat om kårens pengar,
-vem som ska vara kårordförande, fastigheterna Nymble och Osqvik samt
-vilka sektioner som ska finnas.
+[Informationsorganet](/namnder/informationsorganet) har som främsta syfte att sprida information – till, från och mellan Datasektionens medlemmar. Crash & Bränn är de som underhåller och utvecklar denna hemsida och [Tag Monkeys - Datas kodapor](/namnder/tag-monkeys) håller koll på sektionens grafik och design. [dbuggen](http://dbu.gg) är Datasektionens stolta sektionstidning som kommer ut regelbundet. De ger också ut nØlledbuggen till de nyantagna studenterna.
 
-Sektionstidning
----------------
+## Märken och overaller
 
-[dbuggen](http://dbu.gg) är Datasektionens stolta sektionstidning där sär
-skrivningar är lika sär som de är skrivna, som ledamöterna i Svenska Akademien
-drömmer våta drömmar om på nätterna och inte minst de som har tagit på sig att
-föra det skrivna ordet som en nymodighetens virvelvind genom sektionen.
-nØlledbuggen är dbuggens årliga publikation för nyantagna studenter. 
+[Prylmångleriet](/namnder/prylmangleriet) är Datasektionens egna nasare. De säljer saker som ovvar, märken, pins och alla andra möjliga prylar. Prylmånglaren hittas oftast i META och kör semireguljära försäljningar.
 
-Jämlikhetsarbete
-----------------
+## Musikverksamhet
 
-Jämlikhetsnämnden är nämnden som arbetar för att alla ska känna sig lika
-trygga och lika mycket värda på Datasektionen. Hit vänder du dig om du
-har frågor om trakasserier, diskriminering, eller om du utsatts för
-något otrevligt på sektionen. Ingen fråga är för liten! Om du brinner
-för att arbeta mot orättvisor och gillar att ha en åsikt ska du
-självklart gå med i nämnden.
+Datas Musiknämnd [DEMON](/namnder/datasektionens-musiknamnd) finns för att täcka alla dina musikrelaterade behov. Vare sig du vill spela musik, DJ:a musik eller snacka musik. Eller bara stå och üntza på en pub. Man kan göra mycket med musik.
 
-Konglig Östrogennämnden, KÖN
-----------------------------
+## Mottagning av nya studenter
 
-Trots Datasektionens så få men ack så underbara tjejer finns ett ljus i
-tunneln: Konglig Östrogennämnden är nämnden som hjälper tjejer på data
-att nätverka med varandra! Denna nystartade nämnd på Datasektionen
-anordnar middagar under året och samarbetar även med Näringslivsgruppen
-anordna företagsevents. Under hösten kommer det dessutom hållas en
-tjejgasque! Låter det som något för dig? Håll utkik efter mer info på
-datasektionens hemsida!
+Mottagningen ser till att de nyantagna till Datasektionen känner sig välkommna och har roligt. Du hittar schema och all information om mottagningen på [mottagningens sida](/namnder/mottagningen).
 
-Spex
-----
+## Styrelse
 
-METAspexet är ett samarbete mellan Datasektionen och Sektionen för
-Medieteknik. Ändamålet är att bringa glädje till sektionernas medlemmar
-genom att ägna sig åt [spex](https://sv.wikipedia.org/wiki/Spex), gyckel,
-musik, dans och andra sceniska underhållningsformer samt ytterligare
-stärka sektionernas samverkan. De verkar för en årlig uppsättning av
-METAspexet.
+Datasektionens styrelsen [D-rektoratet](/organisation/sammansattning) har det övergripande ansvaret för allt som händer på sektionen. Styrelsens ansvarsområden är uppdelade mellan dess ledamöter. Styrelsens huvuduppgift är genomföra beslut som tas på sektionsmötena.
 
-Idrottsverksamhet
------------------
+## Kårfullmäktigeledamöter
 
-Idrottsnämndens aktiviteter beror helt på vad dess medlemmar vill göra.
-Vi satsar bl a på att delta i alla grenar i THS-Mästerskapen samt att
-hålla kontinuerliga aktiviteter vid sidan av studierna.
+Datasektionens kårfullmäktigeledamöter representerar sektionen i Kårfullmäktige som är Tekniska Högskolans Studentkår högsta beslutande organ. Kårfullmäktige bestämmer bland annat om kårens pengar, vem som ska vara kårordförande, fastigheterna Nymble och Osqvik samt vilka sektioner som ska finnas.
 
-Internationell verksamhet / International activities
-----------------------------------------------------
+## Internationell verksamhet / International activities
 
-Datas Internationella Utskott, DIU, anordnar mottagningen av de
-internationella studenterna. / Datasektionen International Committee
-organizes the reception of international students.
+Datas Internationella studentkoordinator anordnar mottagningen av de internationella studenterna och hjälper dem att komma i kontakt med sektionen. 
 
-Studieresa
-----------
+The International Student Coordinator organizes the reception of international students and helps them to learn about Datasektionen.
 
-Studieresan, Studs, anordnas som en projektkurs för dataloger i
-slutet av sin utbildning. Projektets mål är att ta sig till ett
-främmande land, lära känna en annan kultur samt förbättra deltagarnas
-kontakter med näringslivet. Eftersom projektet arrangeras som kurs får
-du poäng och dessutom en fantastisk upplevelse.
+## Spex
 
-Märken och overaller, Prylmångleriet
-------------------------------------
+[METAspexet](//metaspexet.se) är ett samarbete mellan Datasektionen och Sektionen för Medieteknik. Ändamålet är att bringa glädje till sektionernas medlemmar genom att ägna sig åt [spex](https://sv.wikipedia.org/wiki/Spex), gyckel, musik, dans och andra sceniska underhållningsformer samt ytterligare stärka sektionernas samverkan.
 
-Vi har alla vaknat en dag och insett att Plattan inte räcker till för
-alla våra inköpsbehov. Av just den anledningen, och en hel del andra,
-finns vi.
+## Studieresa
 
-Prylmångleriet är Datasektionens egna nasare. Allt det som en
-datateknolog kan tänkas behöva som inte främjar studierna har dessa
-krabater på sin försäljningslista. Det gäller saker som ovvar, märken,
-pins och alla andra möjliga prylar. Prylmånglaren hittas oftast i META
-och kör semireguljära försäljningar.
+Studieresan, [Studs](//studieresan.se), anordnas som en projektkurs för dataloger i slutet av sin utbildning. Projektets mål är att ta sig till ett främmande land, lära känna en annan kultur samt förbättra deltagarnas kontakter med näringslivet. Eftersom projektet arrangeras som kurs får du högskolepoäng och dessutom en fantastisk upplevelse.
 
-Skidresa
---------
+## Skidresa
 
-Datasektionen åker varje vinter till Åre (dÅre) för några dagars härlig
-skidåkning och nattliv. Anmälan öppnar efter mottagningen och
-arrangemanget är till självkostnadspris med Skistars studentrabatter.
-
-Musikverksamhet, DEMON
----------------------
-
-Nämnden DEMON finns för att täcka alla dina musikrelaterade behov.
-Ibland känner du för att plocka fram plonkaren i dig, och då plocka fram
-en av syntharna. Eller kanske redo för lite trumträning, och haka på att
-lira i en replokal. Eller bara stå och üntza på en pub. Man kan göra
-mycket med musik.
-
-Badhusfest
-----------
-
-Plums är en fest som varje år anordnas av DKM. Föreställ dig en fest där du är i ett badhus och 
-DKM har slängt in ett par grymma DJs, en äkta delmängd av spritförrådet samt mackor för alla! 
-Som om inte det vore nog kan du självklart kombinera detta med bad och bastu. Allt som 
-allt kan man lätt säga att det är det bästa som händer i en teknologs liv.
-
-Sektionsbilen
--------------
-
-Sektionen har en bil man kan [låna](/sektionen/sektionsbilen)!
+Projektet [dÅre](http://dåre.se) ser till att Datasektionen varje vinter åker till Åre för några dagars härlig skidåkning och nattliv.


### PR DESCRIPTION
Jag räknar inte med att mitt frihetstagande ska komma undan utan kommentarer, jag ändrade ju på rätt mycket. Har säkert gjort något slarvfel också...

Tog bort onödig information som "kolla vår sida för att veta mer" samt olämplig referens till att handla på Plattan (anser det vara olämpligt på vår officiella informationskanal).