### PR TITLE
Gör kontaktuppgifter mer synligt under Näringsliv

### DIFF
--- a/naringsliv/body.md
+++ b/naringsliv/body.md
@@ -13,6 +13,8 @@ kontaktvägar/event, men vi kommer gärna på nya idéer tillsammans med er.
 Hör gärna av er till oss inom näringslivsgruppen, via mail eller
 telefon, för mer information.
 
+> E-post foretag@d.kth.se
+
 ## Pub
 
 Ta chansen och presentera ert företag på någon av våra populära


### PR DESCRIPTION
När man som företag går in på denna sida letar man eg efter mejlen primärt, den bör sådeles synas tydligt tidigare i sidans scan-order.
