### PR TITLE
Removed outdated information about D-Dagen

### DIFF
--- a/en/industry/d-dagen/body.md
+++ b/en/industry/d-dagen/body.md
@@ -10,4 +10,4 @@ have the possibility to offer drinks to students using drink coupons.
 Company representatives will receive breakfast, lunch,
 dinner and fika during the day.
 
-For prices and more information please visist: [ddagen.se](https://ddagen.se).
+For prices and more information please visit: [ddagen.se](https://ddagen.se).

--- a/en/industry/d-dagen/body.md
+++ b/en/industry/d-dagen/body.md
@@ -1,13 +1,13 @@
 # D-Dagen
 
-D-Dagen is the Computer Science Chapter's annual work fair. Hosted by
+D-Dagen is the Computer Science Chapter's annual career fair. Hosted by
 students, D-Dagen creates a space for computer science students and
-companies to interact and develop relations. This year, the work fair takes place
-on the 10th October at the KTH campus on Valhallavägen. A traditional
+companies to meet and develop relations. The career fair usually takes place
+in the beginning of October at the KTH campus on Valhallavägen. Usually, a traditional
 three-course student dinner follows the fair, followed by a pub in order
 for you to mingle with students in a more relaxed environment. You will
 have the possibility to offer drinks to students using drink coupons.
 Company representatives will receive breakfast, lunch,
 dinner and fika during the day.
 
-For prices and more information please see: [ddagen.se/companies](https://ddagen.se/companies).
+For prices and more information please visist: [ddagen.se](https://ddagen.se).

--- a/en/industry/d-dagen/sidebar.md
+++ b/en/industry/d-dagen/sidebar.md
@@ -1,7 +1,7 @@
 ### D-Dagen
 [ddagen.se](https://ddagen.se/)
 
-* For up to date information, visit the website
+* For up-to-date information, visit the website
 * Beginning of October
 * KTH, Campus Valhallavägen
 * The fair's opening hours: 10.00 – 16.00

--- a/en/industry/d-dagen/sidebar.md
+++ b/en/industry/d-dagen/sidebar.md
@@ -1,7 +1,8 @@
-### D-Dagen 2019
+### D-Dagen
 [ddagen.se](https://ddagen.se/)
 
-* Thursday, October 10
+* For up to date information, visit the website
+* Beginning of October
 * KTH, Campus Valhallavägen
 * The fair's opening hours: 10.00 – 16.00
 * E-mail: [d-dagen.sales@d.kth.se](mailto:d-dagen.sales@d.kth.se)

--- a/naringsliv/d-dagen/body.md
+++ b/naringsliv/d-dagen/body.md
@@ -1,18 +1,16 @@
 # D-Dagen
 
-## Det kommer släppas information under början på våren
-
 Konglig Datasektionen anordnar årligen D-Dagen, som är en
 arbetsmarknadsdag där D-studenter och företagen får chans att utveckla
-en närmare kontakt med varandra. I år äger denna heldagsmässa rum den 10
-oktober på campus Valhallavägen. Senare på kvällen har vi en
+en närmare kontakt med varandra. Mässan är en heldagsmässa som oftast äger rum tidigt i
+oktober på campus Valhallavägen. Senare på kvällen har vi vanligen en
 traditionsenlig sittning som även följs av en pub, där ni har
 möjligheten att träffa studenterna i en mer avslappnad miljö. Under
 puben finns det möjlighet att bjuda studenter på valfri dryck i baren
 med hjälp av barbongar. Under dagen blir företagsrepresentanterna bjudna
 på frukost, lunch, fika och middag.
 
-För priser och mer information, vänligen klicka [här](https://ddagen.se/companies).
+För priser och mer information, vänligen besök [ddagen.se](https://ddagen.se).
 
 
 <!---

--- a/naringsliv/d-dagen/sidebar.md
+++ b/naringsliv/d-dagen/sidebar.md
@@ -1,7 +1,8 @@
-### D-Dagen 2019
+### D-Dagen
 [ddagen.se](https://ddagen.se/)
 
-* Torsdagen den 10 oktober
+* Se hemsidan för exakt information
+* Tidig oktober
 * KTH, Campus Valhallavägen
 * Mässans öppettider: 10.00 – 16.00
 * E-post: [d-dagen.sales@d.kth.se](mailto:d-dagen.sales@d.kth.se)


### PR DESCRIPTION
Making sure the information always is correct by using vaguer language and redirecting the reader to the official D-Dagen website. 

It is much easier to have a single source of truth (ddagen.se) compared to having information scattered across multiple places.