### PR TITLE
Updated reference to Budget 2020

### DIFF
--- a/organisation/budget/body.md
+++ b/organisation/budget/body.md
@@ -1,7 +1,7 @@
 Datasektionens budget
 =====================
 ##Budget 2020
-- [Google Drive](https://docs.google.com/spreadsheets/d/1SIU-AxmvwVX5SmDYM4qYRpVMIQwNgoLpj9PJ79BouXE/edit?usp=sharing)
+- [Google Drive](https://drive.google.com/file/d/1b08k0NLBgetpaAbS0YUMFwRuQk8fVIUE/view?usp=sharing)
 
 ##Budget 2019
 - [Google Drive](https://docs.google.com/spreadsheets/d/1X-ArVGgDm6DNXWi4Ncw7DYdIManGOgwNGyatVbL1nW0/edit?usp=sharing)


### PR DESCRIPTION
As we moved to G-Suite the document was copied there and the old version is no longer being updated. This change makes the URL point to the new version.