### PR TITLE
Revert "Add protocols"

### DIFF
--- a/en/organisation/protokoll/body.md
+++ b/en/organisation/protokoll/body.md
@@ -7,10 +7,6 @@ please reach out to [secretary](mailto:sekr@d.kth.se).
 
 ###2021
 
-9/11 Budget-SM ([action minutes](https://yoggi.datasektionen.se/beslutsprotokoll/budget_sm_2021))
-
-29/05 Extra-SM 2 ([action minutes](https://static.datasektionen.se/beslutsprotokoll/extra_sm_2_2021))
-
 18/05, 20/05, 26/05 Val-SM ([action minutes](https://static.datasektionen.se/beslutsprotokoll/val_sm_2021))
 
 02/03, 04/03 Revisions-SM ([discussion minutes](https://static.datasektionen.se/protokoll/revisions_sm_2021)) ([action minutes](https://static.datasektionen.se/beslutsprotokoll/revisions_sm_2021))

--- a/organisation/protokoll/body.md
+++ b/organisation/protokoll/body.md
@@ -1,13 +1,11 @@
 Protokoll
 =========
 
-Protokoll från samtliga Sektionsmöten (SM) och D-rektoratsmöten (DM) läggs upp på denna sida. Vid frågor angående protokoll, kontakta Datasektionens [sekreterare](mailto:sekr@d.kth.se).
+Protokoll från samtliga Sektionsmöten (SM) och D-rektoratsmöten (DM) läggs upp på denna sida. Vid frågor angående protokoll, kontakta Datasektionens sekreterare.
 
 ## Sektionsmöten, SM
 
 ###2021
-
-9/11 Budget-SM ([beslutsprotokoll](https://yoggi.datasektionen.se/beslutsprotokoll/budget_sm_2021))
 
 29/05 Extra-SM 2 ([beslutsprotokoll](https://static.datasektionen.se/beslutsprotokoll/extra_sm_2_2021))
 


### PR DESCRIPTION
Reverts datasektionen/bawang-content#198

There's a mistake in the Budget-CM protocols under paragraph 9.5 "fyllnadsval av revisor". "Revisor" was accidentally replaced by "Ledamot för studiesociala frågor". 