### PR TITLE
uppdatera funktionärer sn

### DIFF
--- a/en/clubs/studienamnden/body.md
+++ b/en/clubs/studienamnden/body.md
@@ -17,7 +17,7 @@ Contact us if you have questions or opinions regarding the education or the stud
 
 Are your lectures incomprehensible? Are there too few opportunities to present your work? Or do you want someone to act as a middle-man between you and the school? Rest assured, we have got your back! Depending on what year you are in, you can always contact your designated year representative or master representative!
 
-Year 1 - Emil [ake-1@d.kth.se](mailto:ake-1@d.kth.se)
+Year 1 - Emil and Mary [ake-1@d.kth.se](mailto:ake-1@d.kth.se)
 
 Year 2 - Kei and Hannah: [ake-2@d.kth.se](mailto:ake-2@d.kth.se)
 
@@ -29,7 +29,7 @@ Master - Sara, Kitty, Elsa: [master@d.kth.se](mailto:master@d.kth.se)
 ### Studying environment
 
 Cold lecture halls? Unergonomic chairs? Is there too much noise? Contact our SSO if you have an opinion!
-SSO: [sso@d.kth.se](mailto:sso@d.kth.se)
+SSO: Emil [sso@d.kth.se](mailto:sso@d.kth.se)
 
 ### Other questions
 
@@ -72,7 +72,7 @@ The SNO is interested in the students' opinions both regarding the education and
 ### Programme responsible student
 The Programme responsible student (PAS) works together with SNO to improve education quality. The PAS is mainly responsible for contact with teachers and other personel at the CSC-school, and generally works with the long-term work within the Study Board.
 
-PAS: Hannah [pas@d.kth.se](mailto:pas@d.kth.se)
+PAS: Abhinav [pas@d.kth.se](mailto:pas@d.kth.se)
 
 ### Chapter Board Representative for Education
 The Chapter Board Representative for Education (D-UF) works for a better studying environment at KTH. The D-UF has the larger picture of the education. The D-UF is also the communication link between the Chapter Board (D-Rek) and the SNO and PAS.

--- a/namnder/studienamnden/body.md
+++ b/namnder/studienamnden/body.md
@@ -17,7 +17,7 @@ Kontakta oss om du har frågor om eller kommentarer kring studierna eller studie
 
 Obegripliga föreläsningar? Saknas det redovisningstillfällen? Eller vill du att en student är din mellanhand gentemot skolan? Då vet du att du har någon som representerar dig. Beroende på vilket år du går ska du höra av dig till din årskursrepresentant eller masterstudent!
 
-År 1 - Emil [ake-1@d.kth.se](mailto:ake-1@d.kth.se)
+År 1 - Emil och Mary [ake-1@d.kth.se](mailto:ake-1@d.kth.se)
 
 År 2 - Kei och Hannah: [ake-2@d.kth.se](mailto:ake-2@d.kth.se)
 
@@ -29,7 +29,7 @@ Master - Sara, Kitty, Elsa: [master@d.kth.se](mailto:master@d.kth.se)
 ### Studiemiljö
 
 Kalla salar? Oergonomiska stolar? Är det för hög ljudnivå? Kontakta SSO om du har en åsikt!
-SSO: Jesper [sso@d.kth.se](mailto:sso@d.kth.se)
+SSO: Emil [sso@d.kth.se](mailto:sso@d.kth.se)
 
 ### Övriga frågor
 
@@ -74,7 +74,7 @@ SNO är intresserad av studenternas åsikter om både utbildningen och Studienä
 ### Programansvarig student
 Programansvarig student (PAS) arbetar tillsammans med Studienämndens ordförande för att förbättra utbildningens kvalitet. PAS ansvarar huvudsakligen för kontakten till lärare samt utbildningsansvariga på EECS-skolan, och arbetar i allmänhet med det mer långsiktiga fokuset i Studienämnden.
 
-PAS: Hannah [pas@d.kth.se](mailto:pas@d.kth.se)
+PAS: Abhinav [pas@d.kth.se](mailto:pas@d.kth.se)
 
 ### Styrelseledamot för utbildningsfrågor
 Styrelseledamot för utbildningsfrågor (D-UF) verkar för en bättre utbildningskvalitet på sektionen. Tanken är att D-UF ska ha en total bild över utbildningen. Vidare ansvarar ledamoten, D-UF, för kontakten mellan styrelsen och Studienämndens ordförande/Programansvarig student.


### PR DESCRIPTION
Som titeln säger. SN har en ny årskursrepresentant för ettan. Vi har även fått nya personer i rollerna som PAS och SSO efter Glögg-SM.