### PR TITLE
Update board pages

### DIFF
--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -50,10 +50,10 @@ is an authorized signatory for the chapter.
 
 __Contact__
 
-The Vice Treasurer can be reached at [kassor@d.kth.se](mailto:kassor@d.kth.se).
+The Treasurer can be reached at [kassor@d.kth.se](mailto:kassor@d.kth.se).
 
 ## Vice Treasurer - Felix Murnion
-The vice treasurer assists the treasurer with most things related to economics.
+The Vice Treasurer assists the treasurer with most things related to economics.
 
 __Contact__
 
@@ -74,6 +74,7 @@ __Contact person to__
 __Contact__
 
 The Secretary can be reached at [sekr@d.kth.se](mailto:sekr@d.kth.se).
+
 ## Board member of Educational Issues - Daniel Grünler
 
 This board member works closely with the study council and works as a

--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -75,7 +75,7 @@ __Contact__
 
 The Secretary can be reached at [sekr@d.kth.se](mailto:sekr@d.kth.se).
 
-## Board Member of Educational Issues - Daniel Grünler
+## Board Member of Educational Affairs - Daniel Grünler
 
 This board member works closely with the study council and works as a
 link between them and the board.
@@ -94,7 +94,7 @@ __Contact person to__
 
 __Contact__
 
-The Board Member of Educational Issues can be reached at [d-uf@d.kth.se](mailto:d-uf@d.kth.se).
+The Board Member of Educational Affairs can be reached at [d-uf@d.kth.se](mailto:d-uf@d.kth.se).
 
 ## Board member of Student Issues - Malin Svenberg
 
@@ -159,5 +159,5 @@ __Contact person to__
 
 __Contact__
 
-The Board member of Student Issues can be reached at [d-nok@d.kth.se](mailto:d-nok@d.kth.se)
+The Board member of Business Relations can be reached at [d-nok@d.kth.se](mailto:d-nok@d.kth.se)
 .

--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -153,8 +153,6 @@ __Contact person to__
 
 * Head of Business Relations
 
-* D-dagenansvarig
-
 * Chapter Business Fair Officer (D-Dagen)
 
 * Chief Editor

--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -21,6 +21,10 @@ __Contact Person to__
 
 * Auditors
 
+__Contact__
+
+The Chairman can be reached at [ordf@d.kth.se](mailto:ordf@d.kth.se).
+
 ## Vice Chairman - Pontus Söderlund
 The Vice Chairmans primary role is to assist the Chairman and make sure
 that the every board members workload is reasonable and that they are feeling well.
@@ -33,14 +37,27 @@ __Contact Person to__
 
 * Standard-bearer
 
+
+__Contact__
+
+The Vice Chairman can be reached at [vordf@d.kth.se](mailto:vordf@d.kth.se).
+
 ## The Treasurer - Fabian Andréasson
 
 The Treasurer is responsible for the most things related to economics.
 This includes declarations, bills, payments, and accounting. The treasurer
 is an authorized signatory for the chapter.
 
+__Contact__
+
+The Vice Treasurer can be reached at [kassor@d.kth.se](mailto:kassor@d.kth.se).
+
 ## Vice Treasurer - Felix Murnion
 The vice treasurer assists the treasurer with most things related to economics.
+
+__Contact__
+
+The Vice Treasurer can be reached at [vkassor@d.kth.se](mailto:vkassor@d.kth.se).
 
 ## The Secretary - Herman Karlsson
 
@@ -54,6 +71,9 @@ __Contact person to__
 * Student union assembly delegates
 
 
+__Contact__
+
+The Secretary can be reached at [sekr@d.kth.se](mailto:sekr@d.kth.se).
 ## Board member of Educational Issues - Daniel Grünler
 
 This board member works closely with the study council and works as a
@@ -71,6 +91,9 @@ __Contact person to__
 
 * Student safety officer
 
+__Contact__
+
+The Board member of Educational Issues can be reached at [d-uf@d.kth.se](mailto:d-uf@d.kth.se).
 
 ## Board member of Student issues - Malin Svenberg
 
@@ -109,6 +132,10 @@ __Contact person to__
 * D-Fest
 
 
+__Contact__
+
+The Board member of Student issues can be reached at [d-ssf@d.kth.se](mailto:d-ssf@d.kth.se).
+
 ## Board member of business relations - Marcus Nordstedt
 
 Works with business related question and our projects and committees related to this area.
@@ -130,3 +157,8 @@ __Contact person to__
 * Chapter business fair officer
 
 * Chief editor
+
+__Contact__
+
+The Board member of Student issues can be reached at [d-nok@d.kth.se](mailto:d-nok@d.kth.se)
+.

--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -8,7 +8,7 @@ the decisions at chapter meetings are executed, coordinate different parts of th
 
 Each board member is the contact person in the board for some of out elected volunteers.
 
-## The Chairman
+## The Chairman - David Puustinen
 
 The Chairman is in charge of the D-directorate and the contact with THS and other chapters.
 The Chairman and the Vice Chairman work in close cooperation to create a plan and a vision with the rest of the board.
@@ -21,7 +21,7 @@ __Contact Person to__
 
 * Auditors
 
-## Vice Chairman
+## Vice Chairman - Pontus Söderlund
 The Vice Chairmans primary role is to assist the Chairman and make sure
 that the every board members workload is reasonable and that they are feeling well.
 In the case that the Chairman can't fulfill his obligations the Vice Chairman will
@@ -33,16 +33,16 @@ __Contact Person to__
 
 * Standard-bearer
 
-## The Treasurer
+## The Treasurer - Fabian Andréasson
 
 The Treasurer is responsible for the most things related to economics.
 This includes declarations, bills, payments, and accounting. The treasurer
 is an authorized signatory for the chapter.
 
-## Vice Treasurer
+## Vice Treasurer - Felix Murnion
 The vice treasurer assists the treasurer with most things related to economics.
 
-## The Secretary
+## The Secretary - Herman Karlsson
 
 The Secretary is responsible for documenting D-directorate and Chapter Meetings
 and to write protocols and archive them.
@@ -54,7 +54,7 @@ __Contact person to__
 * Student union assembly delegates
 
 
-## Board member of Educational Issues
+## Board member of Educational Issues - Daniel Grünler
 
 This board member works closely with the study council and works as a
 link between them and the board.
@@ -72,7 +72,7 @@ __Contact person to__
 * Student safety officer
 
 
-## Board member of Student issues
+## Board member of Student issues - Malin Svenberg
 
 Works with question regarding the well being of our members, working environment, and
 social events.
@@ -109,7 +109,7 @@ __Contact person to__
 * D-Fest
 
 
-## Board member of business relations
+## Board member of business relations - Marcus Nordstedt
 
 Works with business related question and our projects and committees related to this area.
 Is also responsible for internal communications and that important information is available to our members.

--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -6,7 +6,7 @@ They are the Chairman, Vice Chairman, Treasurer, secretary, and three more board
 for educational issues, student welfare, and business relations. Together they arrange Chapter Meetings, make sure
 the decisions at chapter meetings are executed, coordinate different parts of the chapter, and make strategic and long term plans.
 
-Each boardmember is the contact person in the board for some of out elected volunteers.
+Each board member is the contact person in the board for some of out elected volunteers.
 
 ## The Chairman
 
@@ -24,7 +24,7 @@ __Contact Person to__
 ## Vice Chairman
 The Vice Chairmans primary role is to assist the Chairman and make sure
 that the every board members workload is reasonable and that they are feeling well.
-In the case that the Chariman can't fulfill his obligations the Vice Chairman will
+In the case that the Chairman can't fulfill his obligations the Vice Chairman will
 assume the role as acting Chairman.
 
 The Vice Chairman does many tasks that aren't related to any other board member or function in the chapter.
@@ -35,12 +35,12 @@ __Contact Person to__
 
 ## The Treasurer
 
-The Tresurer is responsible for the most things related to economics.
+The Treasurer is responsible for the most things related to economics.
 This includes declarations, bills, payments, and accounting. The treasurer
 is an authorized signatory for the chapter.
 
 ## Vice Treasurer
-The vice treasurer assists the threasuerer with most things related to economics.
+The vice treasurer assists the treasurer with most things related to economics.
 
 ## The Secretary
 
@@ -63,9 +63,9 @@ __Contact person to__
 
 * Programansvarig student
 
-* The Chariman of the Study Council
+* The Chairman of the Study Council
 
-* The Chariman of the Equality Commitee
+* The Chairman of the Equality Committee
 
 * International student coordinator
 
@@ -111,8 +111,8 @@ __Contact person to__
 
 ## Board member of business relations
 
-Works with business related question and our projects and commitess related to this area.
-Is also responsible for internal communications and that imporant information is avaiable to our members.
+Works with business related question and our projects and committees related to this area.
+Is also responsible for internal communications and that important information is available to our members.
 
 
 __Contact person to__

--- a/en/organisation/sammansattning/body.md
+++ b/en/organisation/sammansattning/body.md
@@ -45,7 +45,7 @@ The Vice Chairman can be reached at [vordf@d.kth.se](mailto:vordf@d.kth.se).
 ## The Treasurer - Fabian Andréasson
 
 The Treasurer is responsible for the most things related to economics.
-This includes declarations, bills, payments, and accounting. The treasurer
+This includes declarations, bills, payments, and accounting. The Treasurer
 is an authorized signatory for the chapter.
 
 __Contact__
@@ -53,7 +53,7 @@ __Contact__
 The Treasurer can be reached at [kassor@d.kth.se](mailto:kassor@d.kth.se).
 
 ## Vice Treasurer - Felix Murnion
-The Vice Treasurer assists the treasurer with most things related to economics.
+The Vice Treasurer assists the Treasurer with most things related to economics.
 
 __Contact__
 
@@ -75,7 +75,7 @@ __Contact__
 
 The Secretary can be reached at [sekr@d.kth.se](mailto:sekr@d.kth.se).
 
-## Board member of Educational Issues - Daniel Grünler
+## Board Member of Educational Issues - Daniel Grünler
 
 This board member works closely with the study council and works as a
 link between them and the board.
@@ -88,15 +88,15 @@ __Contact person to__
 
 * The Chairman of the Equality Committee
 
-* International student coordinator
+* International Student Coordinator
 
-* Student safety officer
+* Student Safety Officer
 
 __Contact__
 
-The Board member of Educational Issues can be reached at [d-uf@d.kth.se](mailto:d-uf@d.kth.se).
+The Board Member of Educational Issues can be reached at [d-uf@d.kth.se](mailto:d-uf@d.kth.se).
 
-## Board member of Student issues - Malin Svenberg
+## Board member of Student Issues - Malin Svenberg
 
 Works with question regarding the well being of our members, working environment, and
 social events.
@@ -106,13 +106,13 @@ __Contact person to__
 
 * Head of the Bar
 
-* Chapter Sports leader
+* Chapter Sports Leader
 
 * Ljud- och ljusansvarig
 
-* Chief of halls
+* Chief of Halls
 
-* Cultural attaché
+* Cultural Attaché
 
 * Prylis
 
@@ -135,9 +135,9 @@ __Contact person to__
 
 __Contact__
 
-The Board member of Student issues can be reached at [d-ssf@d.kth.se](mailto:d-ssf@d.kth.se).
+The Board member of Student Issues can be reached at [d-ssf@d.kth.se](mailto:d-ssf@d.kth.se).
 
-## Board member of business relations - Marcus Nordstedt
+## Board Member of Business Relations - Marcus Nordstedt
 
 Works with business related question and our projects and committees related to this area.
 Is also responsible for internal communications and that important information is available to our members.
@@ -147,19 +147,19 @@ __Contact person to__
 
 * Project Leaders for STUDS
 
-* Chapter systems officer
+* Chapter Systems Officer
 
-* Communications officer
+* Communications Officer
 
 * Head of Business Relations
 
 * D-dagenansvarig
 
-* Chapter business fair officer
+* Chapter Business Fair Officer (D-Dagen)
 
-* Chief editor
+* Chief Editor
 
 __Contact__
 
-The Board member of Student issues can be reached at [d-nok@d.kth.se](mailto:d-nok@d.kth.se)
+The Board member of Student Issues can be reached at [d-nok@d.kth.se](mailto:d-nok@d.kth.se)
 .

--- a/organisation/sammansattning/body.md
+++ b/organisation/sammansattning/body.md
@@ -60,7 +60,7 @@ __Kontakt__
 
 Kassör är nåbar på [kassor@d.kth.se](mailto:kassor@d.kth.se)
 
-## Vice kassör - [Sökes](https://val.datasektionen.se/)
+## Vice kassör - Felix Murnion
 
 Vice kassör arbetar tillsammans med kassören med sektionens ekonomi och finns
 som extra stöd i ekonomiska frågor och arbetar naturligtvis även med bokföring.
@@ -69,7 +69,7 @@ __Kontakt__
 
 Vice kassör är nåbar på [vkassor@d.kth.se](mailto:vkassor@d.kth.se)
 
-## Sekreterare -  [Sökes](https://val.datasektionen.se/)
+## Sekreterare - Herman Karlsson
 
 Sekreteraren är ansvarig för styrdokument, handlingar, protokoll och annan
 formalia på sektionen.


### PR DESCRIPTION
* Fix some spelling issues on English page
  - It would probably be good to change all occurrences `Chairman` to `Chair` on this page, but saved it for a later PR since this should probably be done in more places than this page,
* Add new board members to Swedish page, and all board members to English page
* Add contact info to English page.
  - Should possibly consider changing this to the new `@datasektionen.se` addresses?

Honestly a bit unsure if the names of board members should be added to the English page, since that is much more likely to not be updated when board members change, and It's not really that good for that to be outdated. Probably fine though.