### PR TITLE
fix dead links in studie[r|s] sidebars

### DIFF
--- a/en/studies/sidebar.md
+++ b/en/studies/sidebar.md
@@ -1,10 +1,11 @@
 ## Useful Links
 
-* [Student rights and responsibilities](https://www.kth.se/en/student/studentliv/studentratt/rattigheter-och-skyldigheter-som-student-1.307449)
+* [Student rights and responsibilities](https://www.kth.se/en/student/studier/rattigheter-och-skyldigheter/rattigheter-och-skyldigheter-1.1148520)
 * [KTH Library](https://www.kth.se/en/biblioteket)
 * [Syllabi](https://www.kth.se/student/kurser/program/CDATE?l=en)
-* [EECS Service Center](https://www.kth.se/en/eecs/kontakt/studentexpedition-och-servicecenter-1.21727)
-* [Exchange Studies](https://www.kth.se/en/student/program/utlandsstudier/utbyte/utbytesstudier-1.4396)
+* [EECS Service Center](https://www.kth.se/en/eecs/kontakt/studentexpedition-eecs-1.21727)
+* [Exchange Studies](https://www.kth.se/en/student/studier/utlandsstudier/utbyte)
 * [Schedules](https://www.kth.se/schema)
 * [Find your way at KTH](https://www.kth.se/places)
 * [Courses](https://www.kth.se/student/kurser/sokkurs?l=en)
+* [FAQ by THS](https://ths.kth.se/en/help)

--- a/studier/sidebar.md
+++ b/studier/sidebar.md
@@ -1,16 +1,16 @@
 ## Användbara länkar
 
-* [Studenträtt](https://www.kth.se/student/studentliv/studentratt)
+* [Studenträtt](https://www.kth.se/student/studier/rattigheter-och-skyldigheter)
 * [KTH bibliotek](https://www.kth.se/kthb)
 * [Utbildningsplaner](https://www.kth.se/student/kurser/program/CDATE)
 * [Programsidan](https://www.kth.se/social/program/cdate/)
-* [EECS servicecenter](https://www.kth.se/eecs/kontakt/studentexpedition-och-servicecenter-1.21727)
-* [EECS-kansliet och studievägledning](https://www.kth.se/student/studievagledning-kontakt/kontakt-studievagledning-pa-program-1.84623)
+* [EECS studentexpedition och servicecenter](https://www.kth.se/eecs/kontakt/studentexpedition-eecs-1.21727)
+* [Studievägledare och Internationell koordinator](https://www.kth.se/student/kontakt/kontaktuppgifter/kontakta-oss-pa-datateknik-civilingenjor-300-hp-1.1168558)
 * [Allmän nyttig fakta till studenter på
     KTH](https://www.kth.se/student?programme=d)
-* [Utbytesstudier](https://www.kth.se/student/program/utlandsstudier/utbyte?programme=d)
+* [Utbytesstudier](https://www.kth.se/student/studier/utlandsstudier/utbyte)
 * [Hitta ett schema](https://www.kth.se/schema)
 * [Hitta ett rum/en plats på KTH](https://www.kth.se/places)
-* [Studievägledningen](https://www.kth.se/student/studievagledning-kontakt)
+* [Om studievägledning](https://www.kth.se/student/kontakt/kontaktuppgifter/studievagledning-1.83165)
 * [Kurskatalogen](https://www.kth.se/student/kurser/sokkurs)
-* [FAQ från THS](http://ths.kth.se/contact/faq/education-and-studysocial)
+* [FAQ från THS](https://ths.kth.se/sv/help)


### PR DESCRIPTION
## Describe your changes
There were several dead links in the sidebars of the studies/studier pages (see https://github.com/datasektionen/bawang-content/issues/373). These have been taken care of.

I also made some very minor changes to reflect the changed layout of the EECS pages, and to add a link to the THS FAQ in the Studies sidebar. 

In the future we should probably add more links for the MsC programmes, but I'll leave that for another issue/pull request.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
- [x] I have updated both Swedish and English pages (if not motivate why)
