### PR TITLE
Add discord server info

### DIFF
--- a/en/chapter/body.md
+++ b/en/chapter/body.md
@@ -13,7 +13,7 @@ those below!
 Duscussion Forums
 -------------------
 
-The chapter has a [Discord server](https://dsekt.se/discord), a chat platform where chapter members can discuss both study-related topics and extracurricular chapter-related activities. The server hosts course channels for the program's courses where students can get help. Events that fall under the activity categories below are also advertised there. All students at KTH are welcome to join the server via the following link: https://dsekt.se/discord.
+The chapter has a [Discord server](https://dsekt.se/discord), a chat platform where chapter members can discuss both study-related topics and extracurricular chapter-related activities. The server hosts course channels for the program's courses where students can get help. Events that fall under the activity categories below are also advertised there. All students at KTH are welcome to join the server via the following link: [dsekt.se/discord](https://dsekt.se/discord).
 
 
 Party activities, DKM

--- a/en/chapter/body.md
+++ b/en/chapter/body.md
@@ -10,6 +10,12 @@ a bit like a fraternity (but more open). In the chapter there are
 several groups doing specific stuff that interests them. Read more about
 those below!
 
+Duscussion Forums
+-------------------
+
+The chapter has a [Discord server](https://dsekt.se/discord), a chat platform where chapter members can discuss both study-related topics and extracurricular chapter-related activities. The server hosts course channels for the program's courses where students can get help. Events that fall under the activity categories below are also advertised there. All students at KTH are welcome to join the server via the following link: https://dsekt.se/discord.
+
+
 Party activities, DKM
 -------------------
 

--- a/sektionen/body.md
+++ b/sektionen/body.md
@@ -1,6 +1,10 @@
 # Konglig Datasektionen
 
-Datasektionen är en ideell [studentsektion](https://sv.wikipedia.org/wiki/Studentsektion) under [Tekniska Högskolans Studentkår](http://ths.kth.se) som finns till för att alla som läser Datateknik på KTH ska få en så bra studietid som möjligt, dels genom att bevaka kurserna som vi läser och dels genom att ordna aktiviteter utanför studierna. På sektionen finns det flera nämnder som har olika verksamhet. Du kan läsa mer om olika saker de gör här nedan.
+Datasektionen är en ideell [studentsektion](https://sv.wikipedia.org/wiki/Studentsektion) under [Tekniska Högskolans Studentkår](http://ths.kth.se) som finns till för att alla som läser Datateknik på KTH ska få en så bra studietid som möjligt, dels genom att bevaka kurserna som vi läser och dels genom att ordna aktiviteter utanför studierna. På sektionen finns det flera nämnder som har olika verksamhet. Du kan läsa mer om olika saker de gör här nedan. 
+
+## Diskussionsforum
+
+Sektionen har en [Discordserver](https://dsekt.se/discord), en chattplattform där sektionens medlemmar kan diskutera både studier och sektionens aktiviteter. På servern finns kurskanaler där programmets kurser diskuteras och studenter kan få hjälp. Alla event som faller in under verksamhetskategorierna nedan annonseras också på servern.  Alla studenter vid KTH är välkomna att gå med på servern via följande länk: https://dsekt.se/discord.
 
 ## Festverksamhet
 

--- a/sektionen/body.md
+++ b/sektionen/body.md
@@ -4,7 +4,7 @@ Datasektionen är en ideell [studentsektion](https://sv.wikipedia.org/wiki/Stude
 
 ## Diskussionsforum
 
-Sektionen har en [Discordserver](https://dsekt.se/discord), en chattplattform där sektionens medlemmar kan diskutera både studier och sektionens aktiviteter. På servern finns kurskanaler där programmets kurser diskuteras och studenter kan få hjälp. Alla event som faller in under verksamhetskategorierna nedan annonseras också på servern.  Alla studenter vid KTH är välkomna att gå med på servern via följande länk: https://dsekt.se/discord.
+Sektionen har en [Discordserver](https://dsekt.se/discord), en chattplattform där sektionens medlemmar kan diskutera både studier och sektionens aktiviteter. På servern finns kurskanaler där programmets kurser diskuteras och studenter kan få hjälp. Alla event som faller in under verksamhetskategorierna nedan annonseras också på servern.  Alla studenter vid KTH är välkomna att gå med på servern via följande länk: [dsekt.se/discord](https://dsekt.se/discord).
 
 ## Festverksamhet
 


### PR DESCRIPTION
## Describe your changes

When clicking on the "Mer om Sektionen"-button under "Socialt" on the datasektionen.se front page, there should be a link to and description of the Discord server. This PR adds this missing info for both the Swedish and English pages.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
- [x] I have updated both Swedish and English pages (if not motivate why)
