### PR TITLE
NLG rubrik under näringsliv

### DIFF
--- a/en/industry/body.md
+++ b/en/industry/body.md
@@ -1,4 +1,4 @@
-# Business Relations
+# The Business Relations Group
 
 Do you want to come in contact with computer science students?
 The Computer Science Chapter's Business Relations Group actively works for an increased

--- a/naringsliv/body.md
+++ b/naringsliv/body.md
@@ -1,4 +1,4 @@
-# Näringsliv
+# Näringslivsgruppen
 ​
 Vill ert företag komma i kontakt med Dataloger? Vi i Näringslivsgruppen
 arbetar aktivt för ett ökat samarbete mellan datastudenter och näringsliv. Vi

--- a/naringsliv/body.md
+++ b/naringsliv/body.md
@@ -4,15 +4,15 @@ Vill ert företag komma i kontakt med Dataloger? Vi i Näringslivsgruppen
 arbetar aktivt för ett ökat samarbete mellan datastudenter och näringsliv. Vi
 hjälper er att anordna event där studenter kan komma i kontakt med er och ert
 företag, för att få en inblick i det framtida arbetslivet. 
-​
+
 Om ni t.ex. vill rekrytera eller göra reklam finns det många sätt att gå
 tillväga, exempelvis via en traditionell lunchföreläsning, reklam eller
 annonsering. Här nedan listar vi våra vanligaste
 kontaktvägar/event, men vi kommer gärna på nya idéer tillsammans med er. 
-​ 
+
 Hör gärna av er till oss inom näringslivsgruppen, via mail eller
 telefon, för mer information. 
-​
+
 > E-post foretag@datasektionen.se
 ​
 ## Pub

--- a/naringsliv/body.md
+++ b/naringsliv/body.md
@@ -8,10 +8,10 @@ företag, för att få en inblick i det framtida arbetslivet.
 Om ni t.ex. vill rekrytera eller göra reklam finns det många sätt att gå
 tillväga, exempelvis via en traditionell lunchföreläsning, reklam eller
 annonsering. Här nedan listar vi våra vanligaste
-kontaktvägar/event, men vi kommer gärna på nya idéer tillsammans med er.
+kontaktvägar/event, men vi kommer gärna på nya idéer tillsammans med er. 
 ​ 
 Hör gärna av er till oss inom näringslivsgruppen, via mail eller
-telefon, för mer information.
+telefon, för mer information. 
 ​
 > E-post foretag@datasektionen.se
 ​

--- a/naringsliv/body.md
+++ b/naringsliv/body.md
@@ -3,13 +3,13 @@
 Vill ert företag komma i kontakt med Dataloger? Vi i Näringslivsgruppen
 arbetar aktivt för ett ökat samarbete mellan datastudenter och näringsliv. Vi
 hjälper er att anordna event där studenter kan komma i kontakt med er och ert
-företag, för att få en inblick i det framtida arbetslivet.
+företag, för att få en inblick i det framtida arbetslivet. 
 ​
 Om ni t.ex. vill rekrytera eller göra reklam finns det många sätt att gå
 tillväga, exempelvis via en traditionell lunchföreläsning, reklam eller
 annonsering. Här nedan listar vi våra vanligaste
 kontaktvägar/event, men vi kommer gärna på nya idéer tillsammans med er.
-​
+​ 
 Hör gärna av er till oss inom näringslivsgruppen, via mail eller
 telefon, för mer information.
 ​


### PR DESCRIPTION
Ändrade rubriken på sidan näringsliv från "Näringsliv" till "Näringslivsgruppen" då texten nedanför handlar om NLG och vad NLG erbjuder.

- [x] I have performed a self-review of my changes
- [x] I have updated both Swedish and English pages (if not motivate why)
