### PR TITLE
Remove Enligsh texts from Swedish pages

### DIFF
--- a/en/chapter/lokalbokning/body.md
+++ b/en/chapter/lokalbokning/body.md
@@ -1,4 +1,4 @@
-## To book META
+# To book META
 
 To book META please use the booking system at
 **[bokning.datasektionen.se](http://bokning.datasektionen.se)**. If you
@@ -11,7 +11,7 @@ please ask in your email.
 
 In the booking page you can choose to book META (the entire chapter hall) or the meeting room.
 When booking META, please specify whether or not you are going to serve alcohol (not necessary if you only
-book the meetingroom).
+book the meeting room).
 
 In this year's [cohabitation agreement](https://dsekt.se/samboendeavtal) it is stated (note that the text is translated):
 

--- a/en/clubs/qulturnamnden/meta.toml
+++ b/en/clubs/qulturnamnden/meta.toml
@@ -1,2 +1,2 @@
 Image = "https://stacken.är.den.verkligen.uppe/a.png"
-Title = "Qulturnämnden"
+Title = "Qulture Committee"

--- a/namnder/qulturnamnden/body.md
+++ b/namnder/qulturnamnden/body.md
@@ -9,15 +9,3 @@ Vi i Qulturnämnden försöker se till att Datasektionen får uppleva så mycket
 För att få mer info om event och spelkvällar gå med i vår [Discord](https://discord.gg/4AhGFZg)!
 
 [Vi finns även på Facebook!](https://www.facebook.com/Qulturnamnden/)
-
-## Qulture Committee
-
-Qulture is a big and exciting concept, which can be a lot of things really. At the same time. Just like Quantum mechanics, but completely different, maybe.
-
-Qulture could be, for example, screenings with a completely functional projector, parlour games with players in the parlour, LAN and meetings with cookies, many cookies. We also do not have a locker where we have candy for the chapter's needs.
-
-We in the Qulture Committee try to make sure that the Computer Science chapter experiences as much Qulture as possible, in all of its forms, most of the time. If you feel like something Qultural is missing at Data, or that you’d like to help us in our work, do not hesitate to contact the Qulture Attaché (see contact info to the right). We do not have a membership, anyone is welcome!
-
-For more info about game nights and other events, join our [Discord](https://discord.gg/4AhGFZg)!
-
-[We also have a Facebook-page](https://www.facebook.com/Qulturnamnden/), check it out! (it’s currently in Swedish unfortunately)

--- a/sektionen/lokalbokning/body.md
+++ b/sektionen/lokalbokning/body.md
@@ -1,8 +1,4 @@
-# Bokningar av META / Book META
-
-## Boka META
-
-*English below*
+# Bokningar av META
 
 För att boka META använd bokningssystemet på 
 **[bokning.datasektionen.se](http://bokning.datasektionen.se)**. 
@@ -30,33 +26,6 @@ lokalen"_
 Detta är tolkat som att man inte får boka ett fjärde tillfälle förrän
 ens tre första bokningar är förbrukade. Observera att detta enbart
 gäller för bokningar på samma tid (t ex onsdag 10-12).
-
-------------------------------------------------------------------------
-
-To book META please use the booking system at 
-**[bokning.datasektionen.se](http://bokning.datasektionen.se)**. If you
-have any questions, please contact the chapter-house bosses by email,
-**[lokalbokning@d.kth.se](mailto:lokalbokning@d.kth.se)**. The email
-goes to both the representative from Computer Science but also the one
-from Media (but CS will most likely reply to you). You need to be a
-member of the chapter in order to book META. To get all the rules,
-please ask in your email.
-The top calendar is for all of META, the bottom one for the meetingroom.
-Please specify which you want to book. When booking META, please specify
-whether or not you are going to serve alcohol (not necessary if you only
-book the meetingroom).
-
-In this year's cohabitation agreements (2018) states (note: translated):
-<br>
-*More than three (3) repeated bookings for a time in the week may not
-occur, this to avoid overbooking of the meeting room. Exceptions apply
-to each sections board, which may have a recurrent time of the week.
-Exceptions may also be granted by the local managers or issued in
-conjunction with booking META*
-
-This is interpreted as that you may not book a fourth time before the
-first three bookings are used. Note that this only applies to bookings
-at the same time (for example, Wednesday 10-12).
 
 <div id="calendar"></div>
 <div id="calendar2"></div>


### PR DESCRIPTION
## Describe your changes
English translations of Qulturnämnden and META booking page should only be written on the english page and not below the swedish text on the swedish page.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
- [x] I have updated both Swedish and English pages (if not motivate why)
