### PR TITLE
Speedup docker-compose build

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,5 @@
 <!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
 
 - [ ] I have performed a self-review of my changes
+  - Instructions for quickly viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
 - [ ] I have updated both Swedish and English pages (if not motivate why)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@
 <!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
 
 - [ ] I have performed a self-review of my changes
-  - Instructions for quickly viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
+  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
 - [ ] I have updated both Swedish and English pages (if not motivate why)

--- a/README.md
+++ b/README.md
@@ -23,13 +23,11 @@ Vi har stängt av commits direkt till master.
 
 ## Köra lokalt 
 
-Repot har en docker-compose fil som sköter all setup med `bawang` och `taitan`, så om du vill redigera hemsidan lokalt och vill se dina ändringar innan du pushar så är det bara att köra
+Repot har en `docker-compose`-fil som sköter all setup med `bawang` och `taitan`. Så om du vill redigera hemsidan lokalt och vill se dina ändringar innan du pushar så är det bara att installera `docker` och `docker-compose` och sedan köra
 ```bash
 docker compose up
 ```
 Därefter så kommer sidan vara tillgänglig på `localhost:8000`. Om du ändrar på en sida så är det bara att ladda om webbläsaren för att se dina ändringar.
-
-För tillfället (24-02-15) tar det ett litet tag att bygga första gången du kör det, då `bawang` använder en gammal version av node, men det löses förhoppningsvis snart™.
 
 ## Mörkläggning till mottagningen 🕶️
 Gör så mycket som möjligt i **EN** PR, då blir det mindre jobbigt att reverta förändringarna efter mottagningen. Lägg även till labeln "mörkläggning" på din PR.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   taitan:
     container_name: taitan
     build:
-      context: https://github.com/datasektionen/taitan.git
+      context: https://ghcr.io/datasektionen/taitan
     environment:
       - PORT=5000
       - CONTENT_DIR=/content
@@ -16,9 +16,7 @@ services:
   bawang:
     container_name: bawang
     build:
-      context: https://github.com/datasektionen/bawang.git
-      args:
-        - RAZZLE_TAITAN_URL=http://localhost:5000
+      context: https://ghcr.io/datasektionen/bawang
     environment:
       - TAITAN_URL=http://localhost:5000
       - TAITAN_CACHE_TTL=0


### PR DESCRIPTION
## Describe your changes

Speedup start of  the docker compose by a factor ~100 by using container repositories somewhat unorthodoxly. (~7m  -> ~4s)

The disadvantage with this approach is that it relies on an outside resource to have the correct settings, but it should be fine. I think the speedup is well worth it, since the goal of the compose is to make it easy to test changes locally with the website.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
- [ ] I have updated both Swedish and English pages (if not motivate why)
  - Seemed redundant to create an `docker-compose-sv.yml`
