### PR TITLE
uppdatera Prylis namn

### DIFF
--- a/namnder/prylmangleriet/sidebar.md
+++ b/namnder/prylmangleriet/sidebar.md
@@ -5,7 +5,7 @@ Gå med genom att fylla i denna [länk](https://forms.gle/gaT6EWE5QfaRqNGK9)
 
 #### Prylmånglaren
 
-Lukas Malmberg</br>
+Sofie Bälter</br>
 [prylis@datasektionen.se](mailto:prylis@datasektionen.se)
 
 #### Facebook


### PR DESCRIPTION
Sofie Bälter är prylis 2024

## Describe your changes
Uppdatera namnet på Prylis då Lukas Malmberg var prylis 2023 och Sofie Bälter är prylis 2024

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x ] I have performed a self-review of my changes
  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
- [ ] I have updated both Swedish and English pages (if not motivate why)
