### PR TITLE
add darkmode url for taitan in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Vi har stängt av commits direkt till master.
 
 ## Köra lokalt 
 
-Repot har en `docker-compose`-fil som sköter all setup med `bawang` och `taitan`. Så om du vill redigera hemsidan lokalt och vill se dina ändringar innan du pushar så är det bara att installera `docker` och `docker-compose` och sedan köra
+Repot har en `docker-compose`-fil som sköter all setup med `bawang` och `taitan`. Så om du vill redigera hemsidan lokalt och vill se dina ändringar innan du pushar så är det bara att installera `docker` och sedan köra
 ```bash
 docker compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - PORT=5000
       - CONTENT_DIR=/content
-      - DARKMODE_URL=https://darkmode.datasektionen.se
+      - DARKMODE_URL=false
     volumes:
       - ./:/content
     command: ./taitan -v -w

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   taitan:
     container_name: taitan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - PORT=5000
       - CONTENT_DIR=/content
+      - DARKMODE_URL=https://darkmode.datasektionen.se
     volumes:
       - ./:/content
     command: ./taitan -v -w


### PR DESCRIPTION
## Describe your changes

With the new darmode in taitan, we will need this for the compose to work. Merge after [taitan#28](https://github.com/datasektionen/taitan/pull/28)

~~We should expand with a local version of the darkmode system once the frontend is implemented for it to make it easy to test sensitive stuff.~~

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
- [ ] I have updated both Swedish and English pages (if not motivate why)
