### PR TITLE
JNO ändrar namn på en sidebar Drive-länk

### DIFF
--- a/en/jml/sidebar.md
+++ b/en/jml/sidebar.md
@@ -1,6 +1,6 @@
 # Resources
 
-- [Drive with old workshop cases and lectures](https://drive.google.com/drive/folders/14inafdh29PnG1Z82f7CFC-NAkOJjtz7W?usp=sharing)
+- [Drive with the Chapter's JML-material](https://drive.google.com/drive/folders/14inafdh29PnG1Z82f7CFC-NAkOJjtz7W?usp=sharing)
 - [THS JML Policy](https://drive.google.com/drive/folders/1Yg90ggSuvpP_9858ByotplhSgR01l6aX)
 - [The Chapter's JML policy in Swedish](https://styrdokument.datasektionen.se/jamlikhetspolicy)
 - [The Chapter's Behaviour policy in Swedish](https://styrdokument.datasektionen.se/policies/uppforandepolicy)

--- a/jml/sidebar.md
+++ b/jml/sidebar.md
@@ -1,6 +1,6 @@
 # Resurser
 
-- [Drive med gamla cases och föreläsningar](https://drive.google.com/drive/folders/14inafdh29PnG1Z82f7CFC-NAkOJjtz7W?usp=sharing)
+- [Drive med sektionens JML-material](https://drive.google.com/drive/folders/14inafdh29PnG1Z82f7CFC-NAkOJjtz7W?usp=sharing)
 - [THS JML-policy](https://drive.google.com/drive/folders/1Yg90ggSuvpP_9858ByotplhSgR01l6aX)
 - [Sektionens Jämlikhetspolicy](https://styrdokument.datasektionen.se/jamlikhetspolicy)
 - [Sektionens Uppförandepolicy](https://styrdokument.datasektionen.se/policies/uppforandepolicy)


### PR DESCRIPTION
## Describe your changes
I've renamed a sidebar link to the drive with JML workshops and lectures because I'm planning to add another folder in said drive for JML-enkäter (the summaries only), where chapter members can see the results of each year's JML-survey. Therfore wanted to rename the link to broaden its' contents.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ X] I have performed a self-review of my changes
  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
- [ X] I have updated both Swedish and English pages (if not motivate why)
