### PR TITLE
Corrections on hedersdelta page

### DIFF
--- a/sektionen/hedersdelta/body_en.md
+++ b/sektionen/hedersdelta/body_en.md
@@ -2,7 +2,7 @@ The Honorary Delta (Hedersdeltat in Swedish) is the chapter's finest award. It i
 
 # Nominations to the Honorary Delta
 
-Nominations to the Honorary Delta 2024 are made in this [form](https://dsekt.se/hedersdelta)! You can also make nominations by emailing the [d-Directorate](mailto:drek@datasektionen.se) (the board of the chapter).
+Nominations to the Honorary Delta 2025 are made in this [form](https://dsekt.se/hedersdelta)! You can also make nominations by emailing the [d-Directorate](mailto:drek@datasektionen.se) (the board of the chapter).
 
 # Possessors of Hedersdeltat
 ## Recipients 2024

--- a/sektionen/hedersdelta/body_sv.md
+++ b/sektionen/hedersdelta/body_sv.md
@@ -1,6 +1,6 @@
 Hedersdeltat är Konglig Datasektionens finaste förtjänsttecken och delas
 ut till de personer som synnerligen förtjänstfullt verkat ideellt för
-sektionen. Motiveringar(#motivering) för varje mottagare finnas att
+sektionen. [Motiveringar](#motivering) för varje mottagare finnas att
 läsa längre ner på sidan.
 
 # Hedersdelta-nomineringar

--- a/sektionen/hedersdelta/body_sv.md
+++ b/sektionen/hedersdelta/body_sv.md
@@ -805,7 +805,7 @@ går det även att maila D-rektoratet.
 ## Motivering till utdelandet av förtjänsttecken <a name="motivering"></a>
 
 ---
-## Motiveringar till 2023 års mottagare
+## Motiveringar till 2024 års mottagare
 
 #### David Puustinen <a name="davidpu"></a>
 

--- a/sektionen/hedersdelta/body_sv.md
+++ b/sektionen/hedersdelta/body_sv.md
@@ -5,7 +5,7 @@ läsa längre ner på sidan.
 
 # Hedersdelta-nomineringar
 
-[Här](https://dsekt.se/hedersdelta) kan nomineringar till Hedersdeltat 2024 göras! Självklart
+[Här](https://dsekt.se/hedersdelta) kan nomineringar till Hedersdeltat 2025 göras! Självklart
 går det även att maila D-rektoratet.
 
 # Innehavare av Hedersdeltat

--- a/sektionen/hedersdelta/body_sv.md
+++ b/sektionen/hedersdelta/body_sv.md
@@ -802,9 +802,8 @@ går det även att maila D-rektoratet.
 </dd>
 </dl>
 
-## Motivering till utdelandet av förtjänsttecken <a name="motivering"></a>
+# Motiveringar till utdelandet av förtjänsttecken <a name="motivering"></a>
 
----
 ## Motiveringar till 2024 års mottagare
 
 #### David Puustinen <a name="davidpu"></a>


### PR DESCRIPTION
## Describe your changes
- The title for 2024 hedersdelta motivations was accidentally written "2023".
- The link to the motivations was formatted wrong.
- The title for the motivations should've been a H1 and not H2.
- The year for nomination has been updated to 2025. (D-rek needs to create a new form which the link points to)

I made these changes on Github, that's why there's so many commits lol.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
- [ ] I have updated both Swedish and English pages (if not motivate why)
The motivations doesn't exist in English.