### PR TITLE
Update links to committee pages and IOR contact

### DIFF
--- a/kontakt/body_en.md
+++ b/kontakt/body_en.md
@@ -26,7 +26,7 @@ For general questions, contact our head of communications at:
 Benjamin Widman<br />
 E-mail: [info@datasektionen.se](mailto:info@datasektionen.se)<br />
 
-For questions regarding [datasektionen.se](https://datasektionen.se) or other systems handled by the chapter, contact the chapter's information committee at [ior@datasektionen.se](mailto:ior@datasektionen.se).
+For questions regarding [datasektionen.se](https://datasektionen.se) or other systems handled by the chapter, contact the chapter's Head of IT at [d-sys@datasektionen.se](mailto:d-sys@datasektionen.se).
 
 ## The board
 

--- a/kontakt/body_sv.md
+++ b/kontakt/body_sv.md
@@ -27,7 +27,7 @@ För frågor av allmän karaktär bör du kontakta Datasektionens kommunikatör:
 Benjamin Widman<br />
 E-post: [info@datasektionen.se](mailto:info@datasektionen.se)<br />
 
-Vid frågor eller funderingar som rör Datasektionen.se eller något av våra andra system kan du vända dig till Systemansvarig på [d-sys@datasektionen.se](mailto:d-sys@datasektionen.se) eller Datasektionens Informationsorgan, IOR, på adressen [ior@datasektionen.se](mailto:ior@datasektionen.se).
+Vid frågor eller funderingar som rör [datasektionen.se](https://datasektionen.se) eller något av våra andra system kan du vända dig till Systemansvarig på [d-sys@datasektionen.se](mailto:d-sys@datasektionen.se).
 
 ## Styrelsen
 

--- a/sektionen/body_en.md
+++ b/sektionen/body_en.md
@@ -17,32 +17,30 @@ The chapter has a [Discord server](https://dsekt.se/discord), a chat platform wh
 
 ## International
 
-We have an international student coordinator who knows the most about the CS chapter's international projects. More information can be found at the [International Committee's page](/namnder/internationella-namnden?lang=en) or by sending an [email](mailto:isc@datasektionen.se).
+We have an international student coordinator who knows the most about the CS chapter's international projects. More information can be found at the [International Committee's page](/namnder/eventorganet/internationella-namnden?lang=en) or by sending an [email](mailto:isc@datasektionen.se).
 
 ## Party activities
 
 Few engineering students could go longer than a few days without partying.
-To satisty this need, we have multiple clubs including D-Festeriet and DKM, or the Club Masters of Data.
+To satisfy this need, we have multiple clubs including D-Festeriet and DKM, or the Club Masters of Data.
 
-[DKM](/namnder/dkm?lang=en), is made up of a few nice people who organize totally
+[DKM](/namnder/eventorganet/dkm?lang=en), is made up of a few nice people who organize totally
 incredible parties. You must think they are awesome. They are.
-Parties are held at META almost every wednesday.
+Parties are held at META almost every Wednesday.
 
 ## Keeping an eye on the studies...
 
-The study council makes sure that all CS students get the best education
+The [Study council](/namnder/paverkansorganet/studienamnden?lang=en) makes sure that all CS students get the best education
 possible. We meet at least once a period and discuss how things are going
 in all the different courses and programmes. If you're experiencing problems
 with the faculty or a course, you should contact us!  The study council is
 open for all CS students, so anyone can come to our meetings.
-[Studienämnden](/namnder/studienamnden?lang=en)
-[sno@datasektionen.se](mailto:sno@datasektionen.se)
 
 ## Activities and entertainment
 
-There are many ways to have fun at the CS chater. Apart from interesting
+There are many ways to have fun at the CS chapter. Apart from interesting
 studies and epic parties, _qultural_ events are sometimes organized. This
-could be film- or gaming evenings. We also collaborate with other groups to spread _qulture_ all around the campus. Looking for company? We can help! [QN](/namnder/qulturnamnden?lang=en)
+could be film- or gaming evenings. We also collaborate with other groups to spread _qulture_ all around the campus. Looking for company? We can help! [QN](/namnder/studiesociala-organet/qulturnamnden?lang=en)
 
 ## Industry contact
 
@@ -54,7 +52,7 @@ The chapter also hold an annual career fare, [D-Dagen](/naringsliv/d-dagen?lang=
 
 META is the hall where CS and Media students can meet, eat and party.
 The address is Osquars Backe 21 and the heroes taking care of the place
-are [METAdorerna](/namnder/metadorerna?lang=en).
+are [METAdorerna](/namnder/forvaltningsorganet/metadorerna?lang=en).
 
 ## Student Reception
 

--- a/sektionen/body_sv.md
+++ b/sektionen/body_sv.md
@@ -10,11 +10,11 @@ Sektionen har en [Discordserver](https://dsekt.se/discord), en chattplattform d�
 
 ## Festverksamhet
 
-Fester är något en teknolog sällan klarar sig utan i mer än ett par dagar. För att tillfredsställa behoven finns det flera nämnder såsom D-festeriet och Datas Klubbmästeri. [DKM](/namnder/dkm), som det så enkelt kallas i lekmannatermer, består av ett gäng som definitivt har examen att anordna helt bonkers fester. Du tycker säkert att det här låter extremt bra - det är det.
+Fester är något en teknolog sällan klarar sig utan i mer än ett par dagar. För att tillfredsställa behoven finns det flera nämnder såsom D-festeriet och Datas Klubbmästeri. [DKM](/namnder/eventorganet/dkm), som det så enkelt kallas i lekmannatermer, består av ett gäng som definitivt har examen att anordna helt bonkers fester. Du tycker säkert att det här låter extremt bra - det är det.
 
 ## Studiebevakning
 
-[Studienämnden](/namnder/studienamnden) ansvarar för att granska och förbättra utbildningen. Om du upplever något problem med hur en kurs, någon lärare eller liknande är det till Studienämnden du ska vända dig! Studienämnden är öppen för alla dataloger - vem som helst får komma på våra möten och alla som vill är välkomna att gå med i nämnden.
+[Studienämnden](/namnder/paverkansorganet/studienamnden) ansvarar för att granska och förbättra utbildningen. Om du upplever något problem med hur en kurs, någon lärare eller liknande är det till Studienämnden du ska vända dig! Studienämnden är öppen för alla dataloger - vem som helst får komma på våra möten och alla som vill är välkomna att gå med i nämnden.
 
 ## Näringslivskontakt
 
@@ -23,7 +23,7 @@ vi lite olika specialerbjudanden.
 
 ## Sektionslokal
 
-Datasektionens och Sektionen för Medietekniks gemensamma sektionslokal heter META och är det utrymme på KTH där våra sektionsmedlemmar kan umgås, äta och studera mellan föreläsningarna. META ligger på Osquars Backe 21 och tas hand om sektionslokalsgruppen [METAdorerna](/namnder/metadorerna).
+Datasektionens och Sektionen för Medietekniks gemensamma sektionslokal heter META och är det utrymme på KTH där våra sektionsmedlemmar kan umgås, äta och studera mellan föreläsningarna. META ligger på Osquars Backe 21 och tas hand om sektionslokalsgruppen [METAdorerna](/namnder/forvaltningsorganet/metadorerna).
 
 ## Mottagning av nya studenter
 

--- a/studier/body_en.md
+++ b/studier/body_en.md
@@ -7,7 +7,7 @@ Not sure who to email? Email [sno@datasektionen.se](mailto:sno@datasektionen.se)
 Here is a list of conctact detail regarding issues or questions related to your studies.
 
 ### Chairman of the Study Council
-Contact me if you have questions about your studies. For example, if there are problems in a course. All courses should also have a course representative (student who represents all the students in talks with the faculty) and you migth be able to find your representative [here:](/namnder/studienamnden?lang=en#contact)
+Contact me if you have questions about your studies, for example, if there are problems in a course. All courses should also have a course representative (student who represents all the students in talks with the faculty) and you might be able to find your representative [here](/namnder/paverkansorganet/studienamnden?lang=en#contact).
 
 [sno@datasektionen.se](mailto:sno@datasektionen.se)
 

--- a/studier/body_sv.md
+++ b/studier/body_sv.md
@@ -1,4 +1,4 @@
-#Studier
+# Studier
 Har du problem eller frågor relaterade till studierna? Kolla om svaren finns i [vanliga frågor om studierna](/studier/faq).
 Annars maila någon av de nedan. Är du osäker vem du kan fråga? Maila [sno@datasektionen.se](mailto:sno@datasektionen.se)
 
@@ -6,7 +6,7 @@ Annars maila någon av de nedan. Är du osäker vem du kan fråga? Maila [sno@da
 Här finner du kontaktuppgifter för att ta vidare problem/frågor du kan tänkas ha rörande studier.
 
 ### Studienämndens ordförande
-Kontakta mig om du har frågor/funderingar rörande dina studier. T.ex. att något inte funkar inom en kurs. Vill du kontakta någon mer specifikt inom studienämnden, säg en årskursrepresentant [kolla här](/namnder/studienamnden#kontakt)
+Kontakta mig om du har frågor/funderingar rörande dina studier, t.ex. att något inte funkar inom en kurs. Vill du kontakta någon mer specifikt inom Studienämnden, säg en årskursrepresentant [kolla här](/namnder/paverkansorganet/studienamnden#kontakt).
 
 [sno@datasektionen.se](mailto:sno@datasektionen.se)
 


### PR DESCRIPTION
## Describe your changes
This updates all links to committee pages to point to the new subdirectories. Also, IOR was mentioned as a contact address for system related questions, which is an outdated name and I don't think contact to the committee itself even has to be there since it in practice is just D-SYS using that email so the d-sys email suffices to be there. There're also some minor grammar/language fixes.

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
- [x] I have updated both Swedish and English pages (if not motivate why)
