### PR TITLE
Fix emails for mottagnignen

### DIFF
--- a/namnder/mottagningen/sidebar_en.md
+++ b/namnder/mottagningen/sidebar_en.md
@@ -15,17 +15,17 @@ Tilde Tärnvik<br />
 
 **Lillebror**, <br />
 Casper Reuterlöv<br />
-[lillebror@datasektionen.se](mailto:halvsyster@datasektionen.se)<br />
+[lillebror@datasektionen.se](mailto:lillebror@datasektionen.se)<br />
 076-780 91 11
 
 **Halvbror**, <br />
 Niels Barth<br />
-[halvbror@datasektionen.se](mailto:lillebror@datasektionen.se)<br /> 
+[halvbror@datasektionen.se](mailto:halvbror@datasektionen.se)<br /> 
 072-339 00 18
 
 **Tvillingbror**, <br />
 Adam Egnell <br />
-[tvillingbror@datasektionen.se](mailto:lillasyster@datasektionen.se)<br /> 
+[tvillingbror@datasektionen.se](mailto:tvillingbror@datasektionen.se)<br /> 
 072-315 70 11
 
 {{ if not .reception -}}

--- a/namnder/mottagningen/sidebar_sv.md
+++ b/namnder/mottagningen/sidebar_sv.md
@@ -15,17 +15,17 @@ Tilde Tärnvik<br />
 
 **Lillebror**, <br />
 Casper Reuterlöv<br />
-[lillebror@datasektionen.se](mailto:halvsyster@datasektionen.se)<br />
+[lillebror@datasektionen.se](mailto:lillebror@datasektionen.se)<br />
 076-780 91 11
 
 **Halvbror**, <br />
 Niels Barth<br />
-[halvbror@datasektionen.se](mailto:lillebror@datasektionen.se)<br /> 
+[halvbror@datasektionen.se](mailto:halvbror@datasektionen.se)<br /> 
 072-339 00 18
 
 **Tvillingbror**, <br />
 Adam Egnell <br />
-[tvillingbror@datasektionen.se](mailto:lillasyster@datasektionen.se)<br /> 
+[tvillingbror@datasektionen.se](mailto:tvillingbror@datasektionen.se)<br /> 
 072-315 70 11
 
 {{ if not .reception -}}


### PR DESCRIPTION
## Describe your changes
It was not intentional, nor an easter egg. I just messed up. This branch corrects scuh that lillebror, halvbror and tvillingbror have their correct emails associated with the mailto

## Checklist before requesting a review

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I have performed a self-review of my changes
  - Instructions for easily viewing your changes locally is available in [the readme](https://github.com/datasektionen/bawang-content?tab=readme-ov-file#k%C3%B6ra-lokalt).
- [x] I have updated both Swedish and English pages (if not motivate why)
